### PR TITLE
add (ruleId) to the message.

### DIFF
--- a/sass-lint-server/src/server.ts
+++ b/sass-lint-server/src/server.ts
@@ -233,9 +233,12 @@ function makeDiagnostic(msg): Diagnostic {
 
     let message;
     if (msg.message) {
-        message = msg.message;
+        message = `${msg.message}.`;
+        if (msg.ruleId) {
+            message += ` (${msg.ruleId})`;
+        }
     } else {
-        message = "Unknown error";
+        message = "Unknown error.";
     }
 
     return {

--- a/sass-lint-server/src/server.ts
+++ b/sass-lint-server/src/server.ts
@@ -233,10 +233,7 @@ function makeDiagnostic(msg): Diagnostic {
 
     let message;
     if (msg.message) {
-        message = `${msg.message}.`;
-        if (msg.ruleId) {
-            message += ` (${msg.ruleId})`;
-        }
+        message = `${msg.message} (${msg.ruleId})`;
     } else {
         message = "Unknown error.";
     }


### PR DESCRIPTION
:sparkles: add (ruleId) to the message.
:pencil2: add punctuation (to follow ESLint message format).

I find useful to know the `ruleId` (e.g. when you have to disable a rule).

Example:
```
⚠️ [sass-lint] Space expected between blocks. (empty-line-between-blocks) (25, 1)
```

> I was not able to test the code with 'build/debug' (because of TS Error on L50).
> It was only tested changing the source code in `~/.vscode/extensions`.
> But it was working as expected… 🙃