### PR TITLE
Update README.md to include instructions on disabling [scss]'s formatOnSave

### DIFF
--- a/sass-lint/README.md
+++ b/sass-lint/README.md
@@ -13,6 +13,14 @@ rules.
 
 The extension requires that sass-lint is installed either locally or globally.
 
+To prevent the builtin "SCSS Language Basics" extension from formatting your code regardless of your sass-lint rules, disable formatting on save in your workspace or user settings:
+
+```json
+"[scss]": {
+  "editor.formatOnSave": false
+}
+```
+
 # Configuration options
 
 * `sasslint.enable` - Enable or disable linting.


### PR DESCRIPTION
I propose adding a section on how to disable the automatic formatting which is enabled by default.